### PR TITLE
Rotacion de la camara y cerrar programa con ESC

### DIFF
--- a/BlackCable/BlackCable/BCE/Base/GameStateManager.cpp
+++ b/BlackCable/BlackCable/BCE/Base/GameStateManager.cpp
@@ -24,7 +24,8 @@ GameStateManager* GameStateManager::getPtr()
 }
 void GameStateManager::GameLoop()
 {
-	while (true)
+	//Para que el juego se cierre al poner ESC
+	while (!platform->shouldWindowClose())
 	{
 		try
 		{

--- a/BlackCable/BlackCable/BCE/Base/Platform.cpp
+++ b/BlackCable/BlackCable/BCE/Base/Platform.cpp
@@ -47,7 +47,7 @@ void Platform::init()
 
 	// Set the current context
 	glfwMakeContextCurrent(mainWindow);
-
+	glfwSetInputMode(mainWindow, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 	// Allow modern extension access
 	glewExperimental = GL_TRUE;
 
@@ -136,6 +136,8 @@ void  Platform::HandleKeys(GLFWwindow* window, int key, int code, int action, in
 			Platform::keys[key] = false;
 		}
 	}
+	if (keys[GLFW_KEY_ESCAPE])
+		glfwSetWindowShouldClose(window, 1);
 	(Platform::obj->*Platform::keyboard)(keys);
 }
 
@@ -149,4 +151,8 @@ void Platform::HandleMouseButton(GLFWwindow* window, int button, int action, int
 {
 	(Platform::obj->*Platform::mouse)(-1, -1, action);
 
+}
+
+bool Platform::shouldWindowClose() {
+	return glfwWindowShouldClose(mainWindow);
 }

--- a/BlackCable/BlackCable/BCE/Base/Platform.h
+++ b/BlackCable/BlackCable/BCE/Base/Platform.h
@@ -31,6 +31,7 @@ public:
 	int GetWidth();
 	int GetHeight();
 	float GetDeltaTime();
+	bool shouldWindowClose();
 public:
 	static GameState * obj;
 	static bool (GameState::* keyboard)(std::map<int, bool>);

--- a/BlackCable/BlackCable/BCE/Graphic/Camera.cpp
+++ b/BlackCable/BlackCable/BCE/Graphic/Camera.cpp
@@ -4,6 +4,7 @@ Camera::Camera() {}
 
 Camera::Camera(glm::vec3 startPosition, glm::vec3 startUp, GLfloat startYaw, GLfloat startPitch, GLfloat startMoveSpeed, GLfloat startTurnSpeed)
 {
+	firstMove = true;
 	position = startPosition;
 	worldUp = startUp;
 	yaw = startYaw;
@@ -48,11 +49,23 @@ glm::vec3 Camera::getCameraPosition()
 
 void Camera::mouseControl(GLfloat xChange, GLfloat yChange)
 {
-	xChange *= turnSpeed;
-	yChange *= turnSpeed;
+	if (firstMove) {
+		prevXPos = xChange;
+		prevYPos = yChange;
+		firstMove = false;
+	}
 
-	yaw += xChange;
-	pitch += yChange;
+	float xoffset = xChange - prevXPos;
+	float yoffset = yChange - prevYPos;
+
+	prevXPos = xChange;
+	prevYPos = yChange;
+
+	xoffset *= turnSpeed;
+	yoffset *= turnSpeed;
+
+	yaw += xoffset;
+	pitch -= yoffset;
 
 	if (pitch > 89.0f)
 	{

--- a/BlackCable/BlackCable/BCE/Graphic/Camera.h
+++ b/BlackCable/BlackCable/BCE/Graphic/Camera.h
@@ -31,6 +31,8 @@ private:
 
 	GLfloat moveSpeed;
 	GLfloat turnSpeed;
+	GLfloat prevXPos, prevYPos;
+	float firstMove;
 
 	void update();
 };

--- a/BlackCable/BlackCable/BCE/Graphic/Material.cpp
+++ b/BlackCable/BlackCable/BCE/Graphic/Material.cpp
@@ -1,5 +1,5 @@
 #include "Material.h"
-#include "ShaderManager.h"
+#include "../Base/ShaderManager.h"
 
 
 Material::Material()

--- a/BlackCable/BlackCable/BlackCable.vcxproj
+++ b/BlackCable/BlackCable/BlackCable.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{AAC58711-E8E4-4C7D-9D60-4E1B9A45D84D}</ProjectGuid>
     <RootNamespace>BlackCable</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/BlackCable/BlackCable/Menu.cpp
+++ b/BlackCable/BlackCable/Menu.cpp
@@ -21,7 +21,7 @@ void Menu::Init()
 	this->platform = Platform::GetPtr();
 	this->manager = GameStateManager::getPtr();
 	shaderManager = ShaderManager::getPtr();
-	camera = Camera(glm::vec3(-1.4f, 0.0f, -1.6f), glm::vec3(0.0f, 1.0f, 0.0f), 0.0f, 0.0f, 55.0f, 0.5f);
+	camera = Camera(glm::vec3(-1.4f, 0.0f, -1.6f), glm::vec3(0.0f, 1.0f, 0.0f), 0.0f, 0.0f, 55.0f, 0.1f);
 	shaderManager->initShader(&camera);
 	cube = new CubeModel();
 	cube->Init();
@@ -40,7 +40,8 @@ void Menu::Draw()
 
 bool Menu::MouseInput(int x, int y, bool leftbutton)
 {
-	camera.mouseControl(x, y);
+	if(x != -1 || y != -1)
+		camera.mouseControl(x, y);
 
 	return false;
 }

--- a/BlackCable/BlackCable/main.cpp
+++ b/BlackCable/BlackCable/main.cpp
@@ -1,4 +1,4 @@
-#include "BCE/GameStateManager.h"
+#include "BCE/Base/GameStateManager.h"
 #include "Menu.h"
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
Agregue la rotación, además, el mouse no puede salir de la pantalla del juego, por lo que también añadi la opcion de cerrar todo el programa al precionar ESC, por comodidad en pruebas